### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,50 +6,50 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RedBotMotors			KEYWORD1
-RedBotSensor			KEYWORD1
-RedBotEncoder			KEYWORD1
-RedBotAccel				KEYWORD1
-RedBotBumper			KEYWORD1
-RedBotSoftwareSerial 	KEYWORD1
+RedBotMotors	KEYWORD1
+RedBotSensor	KEYWORD1
+RedBotEncoder	KEYWORD1
+RedBotAccel	KEYWORD1
+RedBotBumper	KEYWORD1
+RedBotSoftwareSerial	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-drive			KEYWORD2
-pivot			KEYWORD2
-rightMotor		KEYWORD2
-leftMotor		KEYWORD2
-rightDrive		KEYWORD2
-leftDrive		KEYWORD2
-stop			KEYWORD2
-coast			KEYWORD2
-brake			KEYWORD2
-rightStop		KEYWORD2
-leftStop		KEYWORD2
-rightCoast		KEYWORD2
-leftCoast		KEYWORD2
-leftBrake		KEYWORD2
-rightBrake		KEYWORD2
-clearEnc		KEYWORD2
-getTicks		KEYWORD2
-read			KEYWORD2
-check			KEYWORD2
-setBGLevel		KEYWORD2
+drive	KEYWORD2
+pivot	KEYWORD2
+rightMotor	KEYWORD2
+leftMotor	KEYWORD2
+rightDrive	KEYWORD2
+leftDrive	KEYWORD2
+stop	KEYWORD2
+coast	KEYWORD2
+brake	KEYWORD2
+rightStop	KEYWORD2
+leftStop	KEYWORD2
+rightCoast	KEYWORD2
+leftCoast	KEYWORD2
+leftBrake	KEYWORD2
+rightBrake	KEYWORD2
+clearEnc	KEYWORD2
+getTicks	KEYWORD2
+read	KEYWORD2
+check	KEYWORD2
+setBGLevel	KEYWORD2
 setDetectLevel	KEYWORD2
-calStatus		KEYWORD2
-enableBump		KEYWORD2
-checkBump		KEYWORD2
+calStatus	KEYWORD2
+enableBump	KEYWORD2
+checkBump	KEYWORD2
 setBumpThresh	KEYWORD2
-RedBotRadio		KEYWORD2
+RedBotRadio	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-NOT_IN_USE		LITERAL1
-WHISKER			LITERAL1
-LENCODER		LITERAL1
-RENCODER		LITERAL1
-SW_SERIAL		LITERAL1
+NOT_IN_USE	LITERAL1
+WHISKER	LITERAL1
+LENCODER	LITERAL1
+RENCODER	LITERAL1
+SW_SERIAL	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords